### PR TITLE
Add publish date to all articles

### DIFF
--- a/_templates/template.md
+++ b/_templates/template.md
@@ -1,6 +1,10 @@
 ---
 # Jekyll 'Front Matter' goes here. Most are set by default, and should NOT be
-# overwritten except in special circumstances. You should set the article's title:
+# overwritten except in special circumstances. 
+# You should set the date the article was last updated like this:
+date: 2020-05-11 # YYYY-MM-DD
+# This will be displayed at the bottom of the article
+# You should set the article's title:
 title: Title goes here
 # The 'title' is automatically displayed at the top of the page
 # and used in other parts of the site.

--- a/wiki/actuation/Pure-Pursuit-Controller-for-Skid-Steering-Robot.md
+++ b/wiki/actuation/Pure-Pursuit-Controller-for-Skid-Steering-Robot.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 Title: Pure-Pursuit based Controller for Skid Steering Robot
 
 ---

--- a/wiki/actuation/index.md
+++ b/wiki/actuation/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Actuation
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/actuation/linear-actuator-resources.md
+++ b/wiki/actuation/linear-actuator-resources.md
@@ -1,4 +1,5 @@
 ---
+date: 2018-05-14
 title: Linear Actuator Resources and Quick Reference
 published: true
 ---

--- a/wiki/actuation/motor-controller-feedback.md
+++ b/wiki/actuation/motor-controller-feedback.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Motor Controller with Feedback
 ---
 In most of the applications for a DC geared motor speed control or position control might be important. This is achieved by implementing feedback control.

--- a/wiki/actuation/pid-control-arduino.md
+++ b/wiki/actuation/pid-control-arduino.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: PID Control on Arduino
 ---
 The main idea behind PID control is fairly simple, but actually implementing it on an Arduino can be tricky. Luckily, the Arduino IDE comes with [a standard library for PID](http://playground.arduino.cc/Code/PIDLibrary).

--- a/wiki/actuation/uln2003a-motor-controller.md
+++ b/wiki/actuation/uln2003a-motor-controller.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Using ULN 2003A as a motor controller
 ---
 ![Using ULN 2003A as a stepper motor controller](assets/ULN2003AMotorController-8ee22.png)

--- a/wiki/actuation/ur5e-control.md
+++ b/wiki/actuation/ur5e-control.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-11-10
 title: Controlling UR5e arm using ROS
 ---
 

--- a/wiki/actuation/vedder-electronic-speed-controller.md
+++ b/wiki/actuation/vedder-electronic-speed-controller.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Vedder Open-Source Electronic Speed Controller
 ---
 

--- a/wiki/common-platforms/asctec-uav-setup-guide.md
+++ b/wiki/common-platforms/asctec-uav-setup-guide.md
@@ -1,6 +1,7 @@
 ---
 date: 2019-03-05
-# Asctec Pelican UAV Setup Guidance
+title: Asctec Pelican UAV Setup Guidance
+---
 
 This document acts as a tutorial on how to set up a [Asctec Pelican UAV](http://www.asctec.de/en/uav-uas-drones-rpas-roav/asctec-pelican/) for autonomous waypoint navigation using ros pakage [asctec_mav_framework](http://wiki.ros.org/asctec_mav_framework). We are setting up an Asctec Quadrotor Pelican running with Ubuntu 14.04 and pre-installed ROS-jade.
 <div style="text-align:center" markdown="1">

--- a/wiki/common-platforms/asctec-uav-setup-guide.md
+++ b/wiki/common-platforms/asctec-uav-setup-guide.md
@@ -1,4 +1,5 @@
-
+---
+date: 2019-03-05
 # Asctec Pelican UAV Setup Guidance
 
 This document acts as a tutorial on how to set up a [Asctec Pelican UAV](http://www.asctec.de/en/uav-uas-drones-rpas-roav/asctec-pelican/) for autonomous waypoint navigation using ros pakage [asctec_mav_framework](http://wiki.ros.org/asctec_mav_framework). We are setting up an Asctec Quadrotor Pelican running with Ubuntu 14.04 and pre-installed ROS-jade.

--- a/wiki/common-platforms/dji-drone-breakdown-for-technical-projects.md
+++ b/wiki/common-platforms/dji-drone-breakdown-for-technical-projects.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-06
 title: DJI Drone Breakdown for Technical Projects
 published: true
 ---

--- a/wiki/common-platforms/dji-sdk.md
+++ b/wiki/common-platforms/dji-sdk.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
  title: Outdoor UAV navigation (focus on DJI SDK)
 ---
 While DJI has been developing great hardware and software to make relatively safe UAV technology commercially available and has made available an amazing SDK to help research and development, sometimes it becomes difficult to get details on their implementation as their documentation is pretty limited. This article will help a beginner quickly understand what kind of flight information they can get using DJI SDK and how they can use it for their specific use case.

--- a/wiki/common-platforms/husky_interfacing_and_communication.md
+++ b/wiki/common-platforms/husky_interfacing_and_communication.md
@@ -1,5 +1,9 @@
 ---
 date: 2019-05-14
+title: Husky Interfacing and Communication
+---
+
+This excerpt covers the basic methodologies to set up communication channels with the Clearpath Husky and make sure the hardware is receiving commands that are input by the user. The article will cover the hardware used for Husky's onboard processing, additional hardware needed for better Localization and a brief description of Husky's ROS packages for Localization.
 
 ## Husky Onboard Controller:
    The main communication channel between the user and the Husky is through an onboard computer. Therefore, based on the project and the algorithms to be run on the Husky, a selection of onboard computer may be made. Nvidia Jetson and Zotac are the two popular onboard computers among Carnegie Mellon University (CMU) Masters in Robotic Systems Development (MRSD) students.  

--- a/wiki/common-platforms/husky_interfacing_and_communication.md
+++ b/wiki/common-platforms/husky_interfacing_and_communication.md
@@ -1,4 +1,5 @@
-   This excerpt covers the basic methodologies to set up communication channels with the Clearpath Husky and make sure the hardware is receiving commands that are input by the user. The article will cover the hardware used for Husky's onboard processing, additional hardware needed for better Localization and a brief description of Husky's ROS packages for Localization.
+---
+date: 2019-05-14
 
 ## Husky Onboard Controller:
    The main communication channel between the user and the Husky is through an onboard computer. Therefore, based on the project and the algorithms to be run on the Husky, a selection of onboard computer may be made. Nvidia Jetson and Zotac are the two popular onboard computers among Carnegie Mellon University (CMU) Masters in Robotic Systems Development (MRSD) students.  

--- a/wiki/common-platforms/index.md
+++ b/wiki/common-platforms/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Common Platforms
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/common-platforms/index0.md
+++ b/wiki/common-platforms/index0.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Actuation
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/common-platforms/pixhawk.md
+++ b/wiki/common-platforms/pixhawk.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Pixhawk UAV Platform
 ---
 This guide is meant for people using UAVs with the Pixhawk hardware and looking to control the UAV through a computer/microprocessor.

--- a/wiki/common-platforms/ros/ros-cost-maps.md
+++ b/wiki/common-platforms/ros/ros-cost-maps.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Cost Maps
 ---
 ## Package to Use

--- a/wiki/common-platforms/ros/ros-global-planner.md
+++ b/wiki/common-platforms/ros/ros-global-planner.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Global Planner
 ---
 There are 3 global planners that adhere to `nav_core::BaseGlobalPlanner` interface: `global_planner`, `navfn` and `carrot_planner`. The `nav_core::BaseGlobalPlanner` provides an interface for global used in navigation.

--- a/wiki/common-platforms/ros/ros-intro.md
+++ b/wiki/common-platforms/ros/ros-intro.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Introduction
 ---
 

--- a/wiki/common-platforms/ros/ros-mapping-localization.md
+++ b/wiki/common-platforms/ros/ros-mapping-localization.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Mapping and Localization
 ---
 ## Mapping

--- a/wiki/common-platforms/ros/ros-motion-server-framework.md
+++ b/wiki/common-platforms/ros/ros-motion-server-framework.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Motion Server Framework
 ---
 This tutorial will help you in setting up the ROS motion server framework developed at the University of Pittsburgh. This framework is built around the ROS Simple Action Server. For better understanding, we have also included an example of a high-level task running on Pixhawk with ROS motion server framework.

--- a/wiki/common-platforms/ros/ros-navigation.md
+++ b/wiki/common-platforms/ros/ros-navigation.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: ROS Navigation
 ---
 

--- a/wiki/computing/arduino.md
+++ b/wiki/computing/arduino.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Arduino
 ---
 This tutorial covers the basics of different Arduinos, and how to implement common functions with them.

--- a/wiki/computing/aws-quickstart.md
+++ b/wiki/computing/aws-quickstart.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-05-11
 title: Amazon Web Services Quickstart
 ---
 

--- a/wiki/computing/index.md
+++ b/wiki/computing/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Computing
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/computing/setup-gpus-for-computer-vision.md
+++ b/wiki/computing/setup-gpus-for-computer-vision.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 title: Setup your GPU Enabled System for Computer Vision and Deep Learning
 ---
 

--- a/wiki/computing/single-board-computers.md
+++ b/wiki/computing/single-board-computers.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Single-Board Computers
 ---
 

--- a/wiki/computing/ubuntu-chromebook.md
+++ b/wiki/computing/ubuntu-chromebook.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Installing stable version of Ubuntu 14.04 on Chromebook
 ---
 Installing Linux on Chromebook Acer C-720 (stable version)

--- a/wiki/computing/upgrading-ubuntu-kernel.md
+++ b/wiki/computing/upgrading-ubuntu-kernel.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Upgrading the Ubuntu Kernel
 ---
 Following are the steps to be followed for upgrading the Ubuntu kernel:

--- a/wiki/datasets/index.md
+++ b/wiki/datasets/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-24
 title: Datasets
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/datasets/traffic-modelling-datasets.md
+++ b/wiki/datasets/traffic-modelling-datasets.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-24
 title: Traffic Modelling Datasets
 ---
 

--- a/wiki/fabrication/3d-printers.md
+++ b/wiki/fabrication/3d-printers.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: 3D Printers
 ---
 **This article is a technology overview of the fundamentals of 3D Printers, especially "Fused Filament Modeling" (FFM) & "Fused Deposition Modeling" (FDM). It explains the fundamentals of 3D Printer technology and applications. It should be useful for those considering working with, designing, or modifying a 3D printer. It is not intended to be a guide for using the lab's 3D printers.**

--- a/wiki/fabrication/cube-pro.md
+++ b/wiki/fabrication/cube-pro.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Building Prototypes in CubePro
 ---
 [Cube Pro](https://www.3dsystems.com/shop/cubepro) is a 3D printing alternative to the popular MakerBot Replicator Series. This is a step-by-step tutorial to using CubePro for developing prototypes and parts. CubePro is available to Carnegie Mellon University Students in Mechanical Engineering cluster.

--- a/wiki/fabrication/fabrication_considerations_for_3D_printing.md
+++ b/wiki/fabrication/fabrication_considerations_for_3D_printing.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-05-16
 title: Fabrication Considerations for 3D printing
 ---
 

--- a/wiki/fabrication/index.md
+++ b/wiki/fabrication/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Fabrication
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/fabrication/machining-prototyping.md
+++ b/wiki/fabrication/machining-prototyping.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Machining and Prototyping
 ---
 https://www.youtube.com/user/dgelbart/videos - 18 incredible videos on basic machining and prototyping of mechanical components

--- a/wiki/fabrication/makerbot-replicator-2x.md
+++ b/wiki/fabrication/makerbot-replicator-2x.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Makerbot Replicator 2x Overview
 ---
 [Makerbot Replicator 2x](https://store.makerbot.com/printers/replicator2x/) is a popular 3D printer used by hobbyists. This page is for information on the Makerbot Replicator 2x.

--- a/wiki/fabrication/milling-process.md
+++ b/wiki/fabrication/milling-process.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Milling Process
 ---
 Milling is one of the most important machining processes. Knowledge of milling would be very helpful in prototyping. Almost all mechatronic design projects would require milling at one time or the other.

--- a/wiki/fabrication/rapid-prototyping.md
+++ b/wiki/fabrication/rapid-prototyping.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Rapid Prototyping
 ---
 

--- a/wiki/fabrication/series-A-pro.md
+++ b/wiki/fabrication/series-A-pro.md
@@ -1,4 +1,5 @@
-The Series A Pro 3-D printer is a reliable platform that offers a large build volume, flexible controls (including the option to add custom G-code), print monitoring, a large range of print materials. Compared to more beginner-friendly but restrictive options, like the MakerBot, the Series A allows more control and flexibility to the quality, speed, and strength of your print. It also allows the use of more print material options including PLA, PETT, PETG, Nylon, and NijaFlex. 
+---
+date: 2017-12-16
 
 ## Software
 The Series A Pro uses a custom version of Cura slicer software,[Cura Type A](https://www.typeamachines.com/downloads#Software), to prepare .STL files for printing. Install, but do not setup Cura until you are ready to setup the Series A Pro on your machine. 

--- a/wiki/fabrication/series-A-pro.md
+++ b/wiki/fabrication/series-A-pro.md
@@ -1,5 +1,8 @@
 ---
 date: 2017-12-16
+title: Series A Pro
+---
+The Series A Pro 3-D printer is a reliable platform that offers a large build volume, flexible controls (including the option to add custom G-code), print monitoring, a large range of print materials. Compared to more beginner-friendly but restrictive options, like the MakerBot, the Series A allows more control and flexibility to the quality, speed, and strength of your print. It also allows the use of more print material options including PLA, PETT, PETG, Nylon, and NijaFlex. 
 
 ## Software
 The Series A Pro uses a custom version of Cura slicer software,[Cura Type A](https://www.typeamachines.com/downloads#Software), to prepare .STL files for printing. Install, but do not setup Cura until you are ready to setup the Series A Pro on your machine. 

--- a/wiki/fabrication/soldering.md
+++ b/wiki/fabrication/soldering.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Soldering
 ---
 A complete and comprehensive 'How to' guide on soldering. A complete set of tutorials has been provided to guide students on effective soldering techniques, the caveats, and other relevant information.

--- a/wiki/fabrication/turning-process.md
+++ b/wiki/fabrication/turning-process.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Turning Process
 ---
 Turning process is done on lathe machines and is ideal for creating components with rotational symmetry. Components such as shafts, sleeves, pulleys etc can be manufactured/modified on a lathe. This two part tutorial gives in a good insight into the usage of the lathe machines.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Wiki Index
 exclude: true
 ---

--- a/wiki/interfacing/blink-1-led.md
+++ b/wiki/interfacing/blink-1-led.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Blink(1) LED
 ---
 ## Introduction

--- a/wiki/interfacing/index.md
+++ b/wiki/interfacing/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Interfacing
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/interfacing/myo.md
+++ b/wiki/interfacing/myo.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Getting Started with the Myo
 ---
 Here are some resources that are useful if you want to get started quickly with the [Myo Gesture Control Armband](https://www.myo.com/). The learning curve is not too steep if you want to make simple apps. It should take you just a couple of days (maybe even less) to get working. However, if you wish to work on more complex problems, the Lua environment used for Myo scripting will not be enough. If you have never worked with APIs before it will add more steepness to your learning curve. I have tried to find as many resources as possible and have structured them in the best way I could here. The lists here are by no means exhaustive but is meant to serve as a reference after you get acquainted with the basics.

--- a/wiki/machine-learning/custom-semantic-data.md
+++ b/wiki/machine-learning/custom-semantic-data.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: Custom data-set for segmentation
 published: true
 ---

--- a/wiki/math/gaussian-process-gaussian-mixture-model.md
+++ b/wiki/math/gaussian-process-gaussian-mixture-model.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-12-16
 # Jekyll 'Front Matter' goes here. Most are set by default, and should NOT be
 # overwritten except in special circumstances. You should set the article's title:
 title: Guassian Process and Gaussian Mixture Model

--- a/wiki/math/registration-techniques.md
+++ b/wiki/math/registration-techniques.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-05-11
 title: Registration Techniques in Robotics
 ---
 Absolute orientation is a fundamental and important task in robotics. It seeks to determine the translational, rotational, and uniform scalar correspondence between two different Cartesian coordinate systems given a set of corresponding point pairs. Dr. Berthold K.P. Horn proposed a closed-form solution of absolute orientation which is often a least-squares problem. Horn validated that his solution holds good for two of the most common representations of rotation: unit quaternions and orthonormal matrices.

--- a/wiki/networking/bluetooth-sockets.md
+++ b/wiki/networking/bluetooth-sockets.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Bluetooth Socket Programming using Python PyBluez
 ---
 This tutorial is intended at providing a primer into Bluetooth programming in general and getting started with PyBluez, a Python Bluetooth module. Bluetooth socket programming is similar to socket programming used by network developers for TCP/IP connections and familiarity with that paradigm will certainly aid understanding although it is not required at all.

--- a/wiki/networking/index.md
+++ b/wiki/networking/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Networking
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/networking/rocon-multi-master.md
+++ b/wiki/networking/rocon-multi-master.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: ROCON Multi-master Framework
 ---
 ROCON stands for *Robotics in Concert*. It is a multi-master framework provided by ROS. It provides easy solutions for multi-robot/device/tablet platforms.

--- a/wiki/networking/ros-distributed.md
+++ b/wiki/networking/ros-distributed.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Running ROS over Multiple Machines
 ---
 Multi­robot systems require intercommunication between processors running on different

--- a/wiki/networking/wifi-hotspot.md
+++ b/wiki/networking/wifi-hotspot.md
@@ -1,4 +1,5 @@
-# Setting up WiFi hotspot at the boot up for Linux devices 
+---
+date: 2019-11-11
 Most of the mobile robot platform uses Linux based Single board computer for onboard computation and these SBCs typically have WiFi or an external WiFi dongle can also be attached. While testing/debugging we need to continuously monitor the performance of the robot which makes it very important to have a remote connection with our robot. So, in this tutorial, we will help you in setting up the WiFi hotspot at the boot for Linux devices like Nvidia Jetson and Intel NUC. We will start with the procedure to set up the WiFi hotspot and then we will discuss how to change Wi-Fi hotspot settings in Ubuntu 18.04 to start it at bootup.
 
 # Table of Contents

--- a/wiki/networking/wifi-hotspot.md
+++ b/wiki/networking/wifi-hotspot.md
@@ -1,5 +1,8 @@
 ---
 date: 2019-11-11
+title: Setting up WiFi Hotspot at the Boot up for Linux Devices 
+---
+
 Most of the mobile robot platform uses Linux based Single board computer for onboard computation and these SBCs typically have WiFi or an external WiFi dongle can also be attached. While testing/debugging we need to continuously monitor the performance of the robot which makes it very important to have a remote connection with our robot. So, in this tutorial, we will help you in setting up the WiFi hotspot at the boot for Linux devices like Nvidia Jetson and Intel NUC. We will start with the procedure to set up the WiFi hotspot and then we will discuss how to change Wi-Fi hotspot settings in Ubuntu 18.04 to start it at bootup.
 
 # Table of Contents

--- a/wiki/networking/xbee-pro-digimesh-900.md
+++ b/wiki/networking/xbee-pro-digimesh-900.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: XBee Pro DigiMesh 900
 ---
 XBee-PRO 900 DigiMesh is useful for setting up your own low bandwidth mesh network. These adapters are great for Mesh Networks and implementations of networks such as VANETs. This tutorial is intended to help you with configuring these adapters and writing a simple python script to initiate bi-directional communication on a serial device.

--- a/wiki/planning/index.md
+++ b/wiki/planning/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: Planning
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/planning/planning-overview.md
+++ b/wiki/planning/planning-overview.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: Overview of Motion Planning
 ---
 The problem of motion planning can be stated as follows: to find an optimal path for the robot to move through gradually from start to goal while avoiding any obstacles in between, given -

--- a/wiki/programming/boost-library.md
+++ b/wiki/programming/boost-library.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Boost C++ Libraries
 ---
 [![Boost Logo](assets/BoostLibrary-f962f.png)](https://www.boost.org/)

--- a/wiki/programming/boost-maps-vectors.md
+++ b/wiki/programming/boost-maps-vectors.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Iterations in maps and vectors using boost libraries
 ---
 Using Boost libraries for maps and vectors in C++ for ROS.

--- a/wiki/programming/cmake.md
+++ b/wiki/programming/cmake.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: CMake and Other Build Systems
 ---
 Build systems are scripts that automate the compilation process. It will be most frequently encountered when compiling software in Linux

--- a/wiki/programming/eigen-library.md
+++ b/wiki/programming/eigen-library.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: How to use Eigen Geometry library for c++
 ---
 

--- a/wiki/programming/git.md
+++ b/wiki/programming/git.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Git
 ---
 Git is a distributed revision control and source code management system with an emphasis on speed. Every Git working directory is a full-fledged repository with complete history and full version tracking capabilities, and is not dependent on network access or a central server. Git is free software distributed under the terms of the GNU GPLv2.

--- a/wiki/programming/index.md
+++ b/wiki/programming/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Programming
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/programming/index0.md
+++ b/wiki/programming/index0.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Actuation
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/programming/multithreaded-programming.md
+++ b/wiki/programming/multithreaded-programming.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Multithreaded Programming as an Alternative to ROS
 ---
 As a software framework for robotics, ROS is an an obvious choice. Having said that, sometimes ROS can be an overkill or can cause trouble due to the amount of abstraction it has. The option of using ROS should be carefully evaluated, especially when you have all your processing on one single embedded system/processor/computer and not distributed across multiple systems. For such a system, a logical alternative is implementing a C/C++ program from scratch and using libraries like pthreads, boost, or others for parallel/pseudo-parallel execution and other functionalities.

--- a/wiki/programming/programming-interviews.md
+++ b/wiki/programming/programming-interviews.md
@@ -1,4 +1,5 @@
 ---
+date: 2018-04-26
 title: Programming Interviews
 ---
 

--- a/wiki/programming/python-construct.md
+++ b/wiki/programming/python-construct.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Python Construct Library
 ---
 

--- a/wiki/programming/tutorials-resources.md
+++ b/wiki/programming/tutorials-resources.md
@@ -1,4 +1,5 @@
 ---
+date: 2018-04-23
 title: General Tutorials and Programming Resources
 ---
 

--- a/wiki/project-management/drone-flight-permissions.md
+++ b/wiki/project-management/drone-flight-permissions.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: Drone Flight Permissions
 published: true
 ---

--- a/wiki/project-management/index.md
+++ b/wiki/project-management/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Project Management
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/project-management/product-development-complex-systems.md
+++ b/wiki/project-management/product-development-complex-systems.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Product Development in Complex System Design
 ---
 ## History (Waterfall Model)

--- a/wiki/project-management/risk-management.md
+++ b/wiki/project-management/risk-management.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Risk Management
 ---
 Risk management is an important process, but can easily turn into an exercise in making a list of items that people think about once and never look at again. There can be little accountability and - if only listed by name with a nebulous category - no real grasp of the risks' impact or what should be done about them.

--- a/wiki/sensing/adafruit-gps.md
+++ b/wiki/sensing/adafruit-gps.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Adafruit GPS
 ---
 ![Adafruit GPS Components](assets/AdafruitGPS-c715f.png) ![Adafruit GPS Assembled](assets/AdafruitGPS-69ceb.png)

--- a/wiki/sensing/apriltags.md
+++ b/wiki/sensing/apriltags.md
@@ -1,4 +1,5 @@
 ---
+date: 2018-08-30
 title: AprilTags
 ---
 AprilTags is a visual fiducial system, useful for a wide variety of tasks including augmented reality, robotics, and camera calibration. The tags provide a means of identification and 3D positioning, even in low visibility conditions. The tags act like barcodes, storing a small amount of information (tag ID), while also enabling simple and accurate 6D (x, y, z, roll, pitch, yaw) pose estimation of the tag.

--- a/wiki/sensing/camera-calibration.md
+++ b/wiki/sensing/camera-calibration.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Camera Calibration
 ---
 

--- a/wiki/sensing/camera-imu-calibration.md
+++ b/wiki/sensing/camera-imu-calibration.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-05-07
 title: IMU-Camera Calibration using Kalibr
 ---
 This tutorial will help you in setting up the Kaliber library developed at ETH Zurich for combined IMU-Camera calibration. 

--- a/wiki/sensing/computer-vision-considerations.md
+++ b/wiki/sensing/computer-vision-considerations.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Computer Vision for Robotics- Practical Considerations
 ---
 Things to take care of when working with vision in robotics:

--- a/wiki/sensing/delphi-esr-radar.md
+++ b/wiki/sensing/delphi-esr-radar.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Delphi ESR Radar
 ---
 

--- a/wiki/sensing/index.md
+++ b/wiki/sensing/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Sensing
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/sensing/opencv-stereo.md
+++ b/wiki/sensing/opencv-stereo.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: OpenCV Stereo Vision Processing
 ---
 For a stereo vision camera, there are multiple operations that can be done like tracking, detection, position estimation, etc. OpenCV has lot of libraries which are much faster than MATLAB's computer vision toolbox.

--- a/wiki/sensing/pcl.md
+++ b/wiki/sensing/pcl.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 title: Point Cloud Library (PCL), 3D Sensors and Applications
 ---
 

--- a/wiki/sensing/photometric-calibration.md
+++ b/wiki/sensing/photometric-calibration.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-21
 title: Photometric Calibration
 ---
 

--- a/wiki/sensing/speech-recognition.md
+++ b/wiki/sensing/speech-recognition.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Speech Recognition
 ---
 Speech Recognition can be a very efficient and powerful way to interface with a robot. It has its downsides since it requires a parser to do something intelligent and be intuitive to use. Also, it is not the most reliable mode of communication since it is plagued with background noise in a regular environment and is prone to false matches.

--- a/wiki/simulation/Building-a-Light-Weight-Custom-Simulator.md
+++ b/wiki/simulation/Building-a-Light-Weight-Custom-Simulator.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-05-11
 title: Building a Light Weight Custom Simulator
 published: true
 ---

--- a/wiki/simulation/Design-considerations-for-ROS-architectures.md
+++ b/wiki/simulation/Design-considerations-for-ROS-architectures.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-05-11
 title: Design considerations for ROS Architectures
 ---
 # Overview

--- a/wiki/simulation/NDT-Matching-with-Autoware.md
+++ b/wiki/simulation/NDT-Matching-with-Autoware.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-05-11
 title: NDT Matching with Autoware
 published: true
 ---

--- a/wiki/simulation/Spawning-and-Controlling-Vehicles-in-CARLA.md
+++ b/wiki/simulation/Spawning-and-Controlling-Vehicles-in-CARLA.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-10
 title: Spawning and Controlling Vehicles in CARLA
 published: true
 ---

--- a/wiki/state-estimation/OculusPrimeNavigation.md
+++ b/wiki/state-estimation/OculusPrimeNavigation.md
@@ -1,4 +1,5 @@
-# Oculus Prime Navigation
+---
+date: 2017-08-15
 
 There are multiple techniques to carry out way-point navigation on the Oculus Prime platform using the navigation stack.
 

--- a/wiki/state-estimation/OculusPrimeNavigation.md
+++ b/wiki/state-estimation/OculusPrimeNavigation.md
@@ -1,5 +1,7 @@
 ---
 date: 2017-08-15
+title: Oculus Prime Navigation
+---
 
 There are multiple techniques to carry out way-point navigation on the Oculus Prime platform using the navigation stack.
 

--- a/wiki/state-estimation/adaptive-monte-carlo-localization.md
+++ b/wiki/state-estimation/adaptive-monte-carlo-localization.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 title:  Adaptive Monte Carlo Localization
 ---
 ## What is a particle filter?

--- a/wiki/state-estimation/index.md
+++ b/wiki/state-estimation/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: State Estimation
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/state-estimation/orb-slam2-setup.md
+++ b/wiki/state-estimation/orb-slam2-setup.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-05-07
 title: ORB SLAM2 Setup Guidance 
 ---
 This tutorial will help you in setting up the ORB SLAM2 on SBC. We will start with the installation procedure for the stereo mode and then we will discuss the changes required in the stereo camera's yaml configuration file. Since the ORB SLAM2 code doesn't publish pose output, we have added a separate section which explains how to add the ROS publisher support for the stereo mode. 

--- a/wiki/state-estimation/radar-camera-sensor-fusion.md
+++ b/wiki/state-estimation/radar-camera-sensor-fusion.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-11-13
 title: 'Sensor Fusion and Tracking'
 published: true
 ---

--- a/wiki/state-estimation/ros-cost-maps.md
+++ b/wiki/state-estimation/ros-cost-maps.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Cost Maps in ROS
 ---
 ## Package to Use

--- a/wiki/state-estimation/ros-mapping-localization.md
+++ b/wiki/state-estimation/ros-mapping-localization.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: ROS Mapping and Localization
 ---
 ## Mapping

--- a/wiki/state-estimation/ros-navigation.md
+++ b/wiki/state-estimation/ros-navigation.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Setting up the ROS Navigation Stack for Custom Robots
 ---
 

--- a/wiki/state-estimation/sbpl-lattice-planner.md
+++ b/wiki/state-estimation/sbpl-lattice-planner.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: SBPL Lattice Planner
 ---
 This tutorial covers implementing the Search Based Planning Lab's Lattice Planner in ROS indigo

--- a/wiki/state-estimation/visual-servoing.md
+++ b/wiki/state-estimation/visual-servoing.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-11-13
 title: 'Visual Servoing'
 published: true
 ---

--- a/wiki/system-design-development/cable-management.md
+++ b/wiki/system-design-development/cable-management.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Cable Management
 ---
 Effective cable management is essential for servicing, debugging and creating reliable robotic systems. Cabling is often regarded as one of the less glamorous parts of electrical engineering, but it is an essential and an extremely important part of creating a complete system.

--- a/wiki/system-design-development/index.md
+++ b/wiki/system-design-development/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: System Design & Development
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/system-design-development/mechanical-design.md
+++ b/wiki/system-design-development/mechanical-design.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Mechanical Design
 ---
 This section will provide you some of the design criteria’s and consideration you should keep in mind when developing a mechanical system:

--- a/wiki/system-design-development/pcb-design.md
+++ b/wiki/system-design-development/pcb-design.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: PCB Design Notes
 ---
 ## Software Tools

--- a/wiki/system-design-development/subsystem-interface-modeling.md
+++ b/wiki/system-design-development/subsystem-interface-modeling.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: System-Subsystem-Interface Modeling
 ---
 A useful tool in system engineering is the system model, which can drive development, requirements generation, design, and just about anything else to do with your project. While the WBS, schedule, and other tools are good for their particular area, the system model has the potential to be useful in replacing all your other planning methods, becoming the one-stop source for information about your project.

--- a/wiki/system-design-development/system-engineering.md
+++ b/wiki/system-design-development/system-engineering.md
@@ -1,3 +1,4 @@
 ---
+date: 2017-08-15
 title: System Engineering
 ---

--- a/wiki/tools/altium-circuitmaker.md
+++ b/wiki/tools/altium-circuitmaker.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Altium Circuit Maker
 ---
 Altium Circuitmaker is a Community Driven PCB Design Application. Circuitmaker can be downloaded [here](http://www.circuitmaker.com). It requires a user account since most of its features are cloud-based.

--- a/wiki/tools/clion.md
+++ b/wiki/tools/clion.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 # Jekyll 'Front Matter' goes here. Most are set by default, and should NOT be
 # overwritten except in special circumstances. You should set the article's title:
 title: CLion IDE

--- a/wiki/tools/docker.md
+++ b/wiki/tools/docker.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-05-16
 title: Docker 
 ---
 

--- a/wiki/tools/gazebo-simulation.md
+++ b/wiki/tools/gazebo-simulation.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-04-24
 title: Gazebo Simulation
 ---
 This is a tutorial for Gazebo, including how to customize a model and use a sensor plug-in.

--- a/wiki/tools/index.md
+++ b/wiki/tools/index.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-09-13
 title: Tools
 ---
 **This page is a stub.** You can help us improve it by [editing it](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io).

--- a/wiki/tools/rosbags-matlab.md
+++ b/wiki/tools/rosbags-matlab.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Rosbags In MATLAB
 ---
 Sometimes you would rather analyze a rosbag in MATLAB rather than within the ROS environment. This page describes how to set up the Matlab infrastructure and includes a script example.

--- a/wiki/tools/roslibjs.md
+++ b/wiki/tools/roslibjs.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 title: Web-Based Visualization using ROS JavaScript Library
 ---
 

--- a/wiki/tools/solidworks.md
+++ b/wiki/tools/solidworks.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Getting started with Solidworks
 ---
 

--- a/wiki/tools/stream-rviz.md
+++ b/wiki/tools/stream-rviz.md
@@ -1,4 +1,5 @@
 ---
+date: 2020-02-03
 title: Stream Rviz Visualizations as Images
 ---
 

--- a/wiki/tools/tmux.md
+++ b/wiki/tools/tmux.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: TMUX
 ---
 TMUX is a useful tool to open multiple tabs in the terminal especially while using SSH.

--- a/wiki/tools/udev-rules.md
+++ b/wiki/tools/udev-rules.md
@@ -1,5 +1,8 @@
 ---
 date: 2017-08-15
+title: udev Rules
+---
+
 [udev](https://en.wikipedia.org/wiki/Udev) is the system on Linux operating systems that manages USB devices. By default, when you plug in a USB device, it will be assigned a name like `ttyACM0`. If you are writing code and need to communicate with that device, you will need to know the name of the device. However, if you plug the devices into different ports or in a different order, the automatically assigned names might change. To solve this, you can create custom udev rules to always assign specific devices to a particular name.
 
 > Note that you can put more than one rule in a file -- just make sure that they are on separate lines.

--- a/wiki/tools/udev-rules.md
+++ b/wiki/tools/udev-rules.md
@@ -1,4 +1,5 @@
-# udev Rules
+---
+date: 2017-08-15
 [udev](https://en.wikipedia.org/wiki/Udev) is the system on Linux operating systems that manages USB devices. By default, when you plug in a USB device, it will be assigned a name like `ttyACM0`. If you are writing code and need to communicate with that device, you will need to know the name of the device. However, if you plug the devices into different ports or in a different order, the automatically assigned names might change. To solve this, you can create custom udev rules to always assign specific devices to a particular name.
 
 > Note that you can put more than one rule in a file -- just make sure that they are on separate lines.

--- a/wiki/tools/vim.md
+++ b/wiki/tools/vim.md
@@ -1,4 +1,5 @@
 ---
+date: 2017-08-15
 title: Vim text editor
 ---
 Vim text editor greatly helps speed-up your programming workflow. It has a fairly big learning curve but the shortcuts and macro functions can easily double your productivity. Vim is also modular, enabling you to easily customize it.

--- a/wiki/tools/visualization-simulation.md
+++ b/wiki/tools/visualization-simulation.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-11-12
 # Jekyll 'Front Matter' goes here. Most are set by default, and should NOT be
 # overwritten except in special circumstances. You should set the article's title:
 title: Making Field Testing Easier Through Visualization and Simulation

--- a/wiki/tools/webots.md
+++ b/wiki/tools/webots.md
@@ -1,4 +1,5 @@
 ---
+date: 2019-12-17
 # Jekyll 'Front Matter' goes here. Most are set by default, and should NOT be
 # overwritten except in special circumstances. You should set the article's title:
 title: Webots


### PR DESCRIPTION
This pull request adds the publication/last update date to all articles. This will give readers a better sense of how current and reliable the information in the article is. It will also give contributors the opportunity to update older articles.
-This simply utilized the existing article date functionality already built into `minimal-mistakes-jekyll`
-All articles in the `wiki/` directory had the date the file was last edited (according to git) added to their header
-Instructions were also added to `template.md` to ensure that all future articles have a date included when published