### PR TITLE
Fix broken links

### DIFF
--- a/wiki/programming/git.md
+++ b/wiki/programming/git.md
@@ -46,9 +46,9 @@ One of the best reading resources around git and version control. Contains a ver
 
 ### Intermediate
 
-- [Managing Merge Conflicts | GitHub Learning Lab](https://lab.github.com/githubtraining/managing-merge-conflicts)
-- [Reviewing Pull Requests | GitHub Learning Lab](https://lab.github.com/githubtraining/reviewing-pull-requests)
-- [GitHub Actions Basics | GitHub Learning Lab](https://lab.github.com/githubtraining/github-actions:-hello-world)
+- [Managing Merge Conflicts](https://lab.github.com/githubtraining/managing-merge-conflicts)
+- [Reviewing Pull Requests](https://lab.github.com/githubtraining/reviewing-pull-requests)
+- [GitHub Actions Basics](https://lab.github.com/githubtraining/github-actions:-hello-world)
 - [Cherry Picking Commits](https://www.atlassian.com/git/tutorials/cherry-pick)
 - [Rebasing Branches](https://docs.github.com/en/get-started/using-git/about-git-rebase)
 - [Git Blame](https://www.atlassian.com/git/tutorials/inspecting-a-repository/git-blame)
@@ -58,7 +58,7 @@ One of the best reading resources around git and version control. Contains a ver
 - [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
 - [Hooks, Enforcing Commit-Message Formats & ACLs](https://git-scm.com/book/en/v2/Customizing-Git-An-Example-Git-Enforced-Policy)
 - [A Beginner's Guide to Git Bisect](https://www.metaltoad.com/blog/beginners-guide-git-bisect-process-elimination)
-- [GitHub Action: Continuous Integration | GitHub Learning Lab](https://lab.github.com/githubtraining/github-actions:-continuous-integration)
+- [Continuous Integration Using GitHub Actions](https://lab.github.com/githubtraining/github-actions:-continuous-integration)
 
 ## References & Help
 - [Atlassian Git Cheat Sheet](https://www.atlassian.com/git/tutorials/atlassian-git-cheatsheet): A handy set of commands to have around your desk for those quick command look ups.


### PR DESCRIPTION
Update link text to fix broken link due to issues rendering '|' in
markdown link text on the website.

Reference: https://roboticsknowledgebase.com/wiki/programming/git/

Fixes bug introduced in #113 