### PR TITLE
Add RF Systems Integration Guide to Networking Wiki

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -297,6 +297,8 @@ wiki:
         url: /wiki/networking/wifi-hotspot/
       - title: Real-Time Video Processing on Jetson with GStreamer
         url: /wiki/networking/gstreamer-jetson-realtime-video/
+      - title: Radio Frequency Systems Integration for Autonomous Robotics
+        url: /wiki/networking/radio-frequency-systems-integration/
   - title: Simulation
     url: /wiki/simulation/
     children:

--- a/wiki/networking/index.md
+++ b/wiki/networking/index.md
@@ -27,6 +27,9 @@ This section focuses on **networking techniques, tools, and protocols** commonly
 - **[Real-Time Video Processing on Jetson with GStreamer](/wiki/networking/gstreamer-jetson-realtime-video/)**
   A comprehensive guide to using GStreamer on Jetson Orin for hardware-accelerated video streaming over networks. Covers zero-copy video processing with NVMM, UDP/RTP streaming pipelines, H.264 encoding, and integration with Python/C++ for teleoperation and remote monitoring applications.
 
+- **[Radio Frequency Systems Integration for Autonomous Robotics](/wiki/networking/radio-frequency-systems-integration/)**
+  An introduction to the RF physical layer underlying every wireless robot link. Covers FCC ISM band regulations, frequency selection trade-offs (915 MHz vs 2.4 GHz vs 5 GHz), bandwidth and range fundamentals via Shannon-Hartley and free-space path loss, antenna sizing and polarization, and PCB-level RF design considerations including impedance matching, the no-right-angle rule, critical trace lengths, and inductor placement.
+
 ## Resources
 
 ### General Networking

--- a/wiki/networking/radio-frequency-systems-integration.md
+++ b/wiki/networking/radio-frequency-systems-integration.md
@@ -1,0 +1,126 @@
+---
+date: 2026-04-29
+title: Radio Frequency Systems Integration for Autonomous Robotics
+---
+
+# Radio Frequency Systems Integration for Autonomous Robotics
+
+While significant attention is paid to the development of SLAM (Simultaneous Localization and Mapping) algorithms, control theory and machine learning models, the underlying communication infrastructure often remains a black box for many robotics engineers. However, the reliability of a robot is fundamentally capped by the integrity of its wireless link. Whether a system is transmitting high-definition telemetry, receiving real-time commands, or streaming dense point-cloud data from a LiDAR sensor, the radio frequency (RF) physical layer is the invisible nervous system that enables autonomy. 
+
+Understanding the constraints of the electromagnetic spectrum, the nuances of regulatory frameworks, and the intricacies of high-frequency circuit design is not merely an elective skill but a prerequisite for deploying real-world robotic platforms.
+
+## **TLDR Practical Guidelines: Choosing a Frequency for Your Robot**
+
+### **Case 1: The Indoor Mobile Robot (Warehouse/Domestic)**
+
+For robots operating in indoor environments with many walls and people, 2.4GHz is often a default. However, the 2.4GHz band is extremely crowded with Bluetooth, other Wi-Fi networks, and even microwave ovens. If the robot requires high-bandwidth data (e.g., streaming video for teleoperation), 5GHz is the superior choice because it offers more non-overlapping channels and is generally less congested.
+
+### **Case 2: The Long-Range Aerial or Agricultural Robot**
+
+For drones or agricultural robots operating in open fields, the 915MHz band is ideal. Its ability to penetrate foliage and its superior free-space path loss allow for links that stretch several kilometers. If the budget and infrastructure allow, Private LTE or 5G can provide high-bandwidth and long-range coverage by leveraging dedicated cellular towers.
+
+### **Case 3: The Subsea or Harsh Environment Robot**
+
+In environments like underwater or underground tunnels, traditional RF fails quickly. Subsea robots often rely on acoustic modems or low-frequency RF (in the kilohertz range) that can penetrate conductive saltwater, though at the cost of extremely low bitrates.
+
+Our system (FireSense, 2026), leveraged the 915MHz IEEE 802.11ah protocol (WiFi HaLow) to achieve \~12.5Mbps through thick concrete and metal structures over 50m away. 
+
+## **Regulation of RF Frequencies in USA**
+
+Before a single signal is transmitted, the robotics designer must navigate the complex landscape of international and domestic radio regulations. In the United States, the Federal Communications Commission (FCC) dictates the usage of the radio spectrum to prevent harmful interference between devices competing for "airspace." For robotics, the primary area of interest lies in the unlicensed ISM bands, where operation is permitted without a formal station license, provided the equipment meets specific technical requirements. A comprehensive table of all frequency allocations can be found at:
+
+[https://www.fcc.gov/engineering-technology/policy-and-rules-division/radio-spectrum-allocation/general/table-frequency](https://www.fcc.gov/engineering-technology/policy-and-rules-division/radio-spectrum-allocation/general/table-frequency)
+
+### **ISM Bands**
+
+The Industrial, Scientific, and Medical (ISM) radio bands are portions of the RF spectrum reserved internationally for purposes other than telecommunications, such as your microwave. Historically, these bands were considered "junk" spectrum due to the high levels of interference from industrial machinery. Users of ISM bands must tolerate any interference from ISM applications and have no regulatory protection from other users. By using spread-spectrum techniques, devices can effectively "share" the noisy environment, freeing up more desirable protected spectrum for mission-critical services. 
+
+The most common bands utilized in robotics are 915 MHz, 2.4GHz, and 5GHz. Each is governed by distinct rules under FCC Part 15 for unlicensed communication devices and Part 18 for industrial equipment. The wikipedia page on ISM bands is quite detailed and provides a good starting point for orienting yourself: [https://en.wikipedia.org/wiki/ISM\_radio\_band](https://en.wikipedia.org/wiki/ISM_radio_band). 
+
+The most important design factor for the ISM bands is that the maximum transmit power for an unlicensed device is 1 watt, spread across the transmission spectrum. This will later become important when considering bandwidth transmission.
+
+## **RF Bandwidth, Range, and Attenuation**
+
+Choosing a frequency band is one of the most critical decisions in the design of a robotic system. This choice dictates the maximum data rate, the operational range, and the robot's ability to communicate through obstacles.
+
+### **Bandwidth and Data Throughput**
+
+There is a direct correlation between carrier frequency and available bandwidth. As the frequency increases, the "width" of the available spectrum typically increases, allowing for higher data rates. For example, the 2.4GHz band offers approximately 83.5MHz of total spectrum, while the 5GHz band offers hundreds of megahertz.
+
+The Shannon-Hartley theorem defines the maximum capacity (C) of a channel:
+
+$$C = B \log_2(1 + \mathrm{SNR})$$
+
+where $B$ is the bandwidth and $\mathrm{SNR}$ is the signal-to-noise ratio. In the context of robotics, higher frequencies like 5GHz are essential for bandwidth-heavy tasks such as video streaming or high-density LiDAR data. However, this capacity comes at a cost of reduced range, greater attenuation, and higher power requirements.
+
+### **Range Concentration**
+
+Transmission power is finite. In an RF system, this power is distributed across the selected bandwidth, a concept known as Power Spectral Density (PSD). If a transmitter emits 100mW of power, spreading that power over a wide 20MHz Wi-Fi channel results in a lower power-per-hertz than concentrating that same 100mW into a narrow 100Hz telegraphy signal.
+
+Narrower bandwidths concentrate energy, which increases the SNR at the receiver, thereby enabling further range. This is why long-range technologies like LoRa (Long Range) utilize relatively narrow bandwidths to achieve communications over several kilometers at 915MHz. Conversely, spreading the signal over a wider bandwidth—while reducing range—can provide "processing gain" in spread-spectrum systems, making the signal more resistant to jamming and interference.
+
+### **Interaction with the Physical Environment**
+
+Radio waves interact with their surroundings through reflection, diffraction, and absorption. The degree of this interaction is highly dependent on the frequency.
+
+**Attenuation and Penetration:** Lower frequencies, such as 915MHz, have longer wavelengths, which allow them to penetrate solid objects like walls, foliage, and atmosphere more effectively than higher frequencies. As the frequency increases to 5GHz and beyond, the waves are more easily absorbed or reflected by obstacles, leading to "dead zones" in complex indoor environments.
+
+**Free-Space Path Loss:** The energy of a radio wave spreads out as it travels. The path loss (L) can be approximated by:
+
+$$L = 20 \log_{10}(d) + 20 \log_{10}(f) + 32.45$$
+
+where $d$ is the distance in kilometers and $f$ is the frequency in MHz. Doubling the frequency results in a 6dB loss in signal strength, which equates to a 75% reduction in available energy at the receiver.
+
+## **RF Antennas**
+
+The antenna acts as the bridge between the electrical world of the PCB and the electromagnetic world of the environment. Its design is governed by the wavelength of the signal it is intended to carry.
+
+### **Frequency and Antenna Dimensions**
+
+The wavelength ($\lambda$) of a radio signal is inversely proportional to its frequency, where $c$ is the speed of light:
+
+$$\lambda = \frac{c}{f}$$
+
+A standard quarter-wave ($\lambda/4$) monopole antenna for 915MHz is approximately 8.2cm long. For 2.4GHz, it shrinks to roughly 3.1cm, and for 5GHz, it is a mere 1.5cm.
+
+This physical reality means that lower frequency systems require larger, often external antennas, whereas higher frequency systems can integrate "trace antennas" directly onto the PCB. Trace antennas are space-efficient but highly sensitive to nearby components and ground plane geometry.
+
+### **Radiation Patterns and Polarization**
+
+Robotics applications typically require an "omnidirectional" antenna, which radiates energy in a 360 degree pattern around its axis—often described as a donut shape. However, the orientation of this donut matters. If the transmitting and receiving antennas are not "polarized" in the same direction (e.g., both vertical), a significant portion of the signal will be lost. This is particularly challenging for drones, which may tilt and roll during flight, necessitating the use of circularly polarized antennas to maintain a stable link regardless of orientation.
+
+### **Ground Planes and Mounting**
+
+An antenna is only half of the system; for a monopole, the PCB's ground plane acts as the other half (the "counterpoise"). If the ground plane is too small or non-existent, the antenna's efficiency will plummet. Furthermore, mounting antennas near metal structures—common in robot chassis—will distort the radiation pattern and cause signal reflections that degrade performance.
+
+## **PCB-Level RF Design Considerations**
+
+When signal frequencies exceed a few hundred megahertz, the traces on a PCB can no longer be viewed as simple wires. They become "distributed parameter systems" where the length of the trace is comparable to the wavelength of the signal.
+
+### **PCB Transmission Line Theory and Impedance Matching**
+
+At high frequencies, any change in the physical geometry of a trace can cause an impedance mismatch. Impedance, typically standardized at 50 Ohms in RF systems, must remain constant from the radio chip, through the traces, and into the antenna. If a mismatch occurs, energy is reflected back toward the source, leading to "Return Loss" and reduced transmission range.
+
+Characteristic impedance ($Z_0$) is determined by the trace width ($W$), the thickness of the dielectric substrate ($H$), and the dielectric constant ($\epsilon_r$).
+
+### **PCB No-Right-Angle Rule**
+
+A cornerstone of PCB layout you might have heard is the avoidance of 90 degree corners, and this comes from RF physics. A right angle creates a sudden change in trace width at the corner, which introduces parasitic capacitance and inductance. This discontinuity acts as a tiny antenna, radiating energy away from the trace and causing signal reflections. Best practice dictates using smooth, curved traces or 45 degree chamfered bends. The radius of any curve should be at least three times the trace width to maintain stable impedance.
+
+### **When PCB Traces Become Antennas**
+
+A trace becomes an efficient radiator (an antenna) when its length approaches a significant fraction of the wavelength—typically $\lambda/20$ or more. For a 2.4GHz signal on a PCB, the wavelength is roughly 12.5cm. This means any trace longer than 6mm must be treated as a transmission line.
+
+This phenomenon is not limited to intentional signals. High-speed digital clocks have sharp edges with very fast rise times ($t_r$). These edges contain high-frequency harmonics that can radiate far beyond the fundamental clock frequency. The "Critical Length" beyond which a digital trace must be treated as an RF transmission line is defined by:
+
+$$L_{crit} = \frac{t_r}{2 \times t_{pd}}$$
+
+where $t_{pd}$ is the propagation delay of the PCB material. As robotics processors move toward DDR4 memory and PCIe Gen 3/4 buses, these critical lengths shrink to fractions of an inch, making the entire board a potential source of EMI.
+
+### **Inductor and Component Interference on PCB**
+
+Inductors are essentially coils of wire designed to store energy in a magnetic field. However, in an RF circuit, this magnetic field can easily couple into nearby traces, a phenomenon known as "mutual inductance".
+
+1. **Orthogonal Placement:** To minimize interference, inductors should be placed at 90 degree angles (orthogonally) to each other. This prevents their magnetic fields from aligning and inducing unwanted currents in neighboring components.  
+2. **Distance from High-Power Tracks:** Inductors used in switching power regulators (DC-DC converters) are major noise sources. They should be placed as far as possible from sensitive RF receivers (LNA \- Low Noise Amplifiers) to prevent desensitization.  
+3. **Vias and Parasitics:** Each via used to move a signal between layers adds parasitic inductance and resistance. In RF paths, vias should be minimized, and when unavoidable, they should be surrounded by "stitching vias" that connect ground planes across layers to provide a low-impedance return path.


### PR DESCRIPTION
This pull request adds a comprehensive new resource to the networking section of the robotics wiki, focused on radio frequency (RF) systems integration for autonomous robotics. The main changes are the addition of a detailed guide covering RF fundamentals, regulations, frequency selection, antenna design, and PCB-level RF considerations, as well as updates to navigation and resource listings to surface this new content.

**New RF Systems Resource:**

* Added a new page, `radio-frequency-systems-integration.md`, providing an in-depth guide to RF physical layer topics relevant to robotics, including FCC ISM band regulations, frequency selection (915 MHz vs 2.4 GHz vs 5 GHz), bandwidth and range fundamentals, antenna design, and PCB-level RF best practices.

**Documentation and Navigation Updates:**

* Added "Radio Frequency Systems Integration for Autonomous Robotics" to the networking section of the wiki navigation (`_data/navigation.yml`).
* Included the new RF systems integration guide in the list of networking resources on `networking/index.md`, with a summary of its contents.