### PR TITLE
fix(deps): update vulnerable dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.2)
+    activesupport (8.1.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
@@ -14,10 +14,10 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -216,7 +216,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.18.1)
+    json (2.19.5)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -240,7 +240,7 @@ GEM
       jekyll-include-cache (~> 0.1)
       jekyll-paginate (~> 1.1)
       jekyll-sitemap (~> 1.3)
-    minitest (6.0.2)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     net-http (0.9.1)


### PR DESCRIPTION
This PR updates the following gems to resolve Dependabot security alerts:
- `json` ([Alert 43](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io/security/dependabot/43))
- `activesupport` ([Alert 44](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io/security/dependabot/44), [Alert 45](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io/security/dependabot/45), [Alert 46](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io/security/dependabot/46))
- `addressable` ([Alert 47](https://github.com/RoboticsKnowledgebase/roboticsknowledgebase.github.io/security/dependabot/47))

Verified with `bundle exec jekyll build`.